### PR TITLE
Add selectable LoFi themed curses interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # loopy
-Python based MIDI sequencer and looper
+
+Python based MIDI sequencer and looper.
+
+## Interface themes
+
+Loopy now supports selectable colour themes for its curses interface. Run the
+application with the `--theme` flag to pick the LoFi chilly look or fall back to
+the classic console palette:
+
+```bash
+python loopy.py --theme lofi-chill
+```
+
+To see the available themes and their descriptions, use:
+
+```bash
+python loopy.py --list-themes
+```

--- a/loopy.py
+++ b/loopy.py
@@ -1,10 +1,11 @@
-import mido
-import threading
+import argparse
 import curses
-import time
-import sys
 import logging
-import traceback
+import threading
+import time
+from typing import Optional, Sequence
+
+import mido
 
 from FreeMetronomeChannel import FreeMetronomeChannel
 from FreeMidiChannel import FreeMidiChannel
@@ -12,114 +13,164 @@ from FluidSynthSoundEngine import FluidSynthSoundEngine
 from Project import Project
 from StepChannel import StepChannel
 from StepSequencerChannel import StepSequencerChannel
+from themes import get_theme, iter_themes
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-def render_curses(screen, project):
-    """Curses render function for threading"""
-    try:
-        while True:
-            screen.clear()
-            line = 0
-            for i, channel in enumerate(project.get_channels()):
-                # Show channel name
-                screen.addstr(line, 0, f"Channel {i + 1}: {channel._instrument_name}")
-                if isinstance(channel, StepSequencerChannel):
-                    # Get parent sequencer
-                    sequencer = channel.get_sequencer()
 
-                    # Get children step channels
+def render_curses(screen, project, theme):
+    """Curses render function for threading."""
+    try:
+        colour_pairs = theme.apply(screen)
+        while True:
+            screen.erase()
+            max_y, _ = screen.getmaxyx()
+            line = 0
+
+            header = f"Loopy — {theme.display_name}"
+            screen.addstr(line, 0, header, theme.style("title", colour_pairs))
+            line += 2
+
+            for i, channel in enumerate(project.get_channels()):
+                if line >= max_y - 1:
+                    break
+
+                channel_label = f"Channel {i + 1}: {channel._instrument_name}"
+                screen.addstr(line, 0, channel_label, theme.style("channel_label", colour_pairs))
+
+                if isinstance(channel, StepSequencerChannel):
+                    sequencer = channel.get_sequencer()
                     step_channels = sequencer.get_channels()
 
-                    # Show steps
                     for step_channel in step_channels:
-                        line=line+1
-                        screen.addstr(line, 3, "[")
+                        line += 1
+                        if line >= max_y - 1:
+                            break
+
+                        screen.addstr(line, 3, "[", theme.style("grid", colour_pairs))
                         for j, step in enumerate(step_channel.get_steps()):
-                            if step is None:
-                                # Show non set steps
-                                screen.addstr(line, j * 2 + 4, "o-")
-                            else:
-                                # Show set steps
+                            column = j * 2 + 4
+                            token = "step_off"
+                            glyph = "o-"
+                            if step is not None:
                                 note, velocity = step
-                                if note is None or velocity is None:
-                                    screen.addstr(line, j * 2 + 4, "o-")
-                                else:
-                                    screen.addstr(line, j * 2 + 4, "x-")
-                        screen.addstr(line, 67, "]")
-                line=line+1
-            screen.refresh()  # Refresh screen
-            time.sleep(0.5)   # Refresh rate
+                                if note is not None and velocity is not None:
+                                    token = "step_on"
+                                    glyph = "x-"
+                            screen.addstr(line, column, glyph, theme.style(token, colour_pairs))
+                        screen.addstr(line, 67, "]", theme.style("grid", colour_pairs))
+
+                line += 1
+
+            footer_line = max_y - 1
+            footer = f"Theme: {theme.display_name} ({theme.key})"
+            screen.addstr(footer_line, 0, footer, theme.style("meta", colour_pairs))
+
+            screen.refresh()
+            time.sleep(0.5)
     except curses.error:
-        pass  # Ignore display errors
-    except Exception as e:
-        # Handle all other exceptions
-        logging.error(f"Unexpected error happened: {e}")
-        screen.addstr(10, 0, f"!!! Unexpected error happened: {e} !!!")
-        screen.refresh()
-        time.sleep(10)  
+        pass
+    except Exception as error:  # pragma: no cover - defensive logging for curses thread
+        logging.error("Unexpected error happened: %s", error)
+        try:
+            screen.addstr(10, 0, f"!!! Unexpected error happened: {error} !!!")
+            screen.refresh()
+            time.sleep(10)
+        except curses.error:
+            pass
 
 
-def start_curses_thread(project):
+def start_curses_thread(project, theme):
     def curses_thread(screen):
-        render_curses(screen, project)
+        render_curses(screen, project, theme)
+
     threading.Thread(target=curses.wrapper, args=(curses_thread,), daemon=True).start()
 
-# Create a FluidSynth sound engine instance
-fs_sound_engine = FluidSynthSoundEngine()
 
-# Project with BPM=120 and 4 beats per measure
-project = Project(fs_sound_engine, bpm=120, beats_per_measure=4)
+def build_project() -> Project:
+    fs_sound_engine = FluidSynthSoundEngine()
+    project = Project(fs_sound_engine, bpm=120, beats_per_measure=4)
 
-# Register instruments
-project.get_instrument_registry().register_instrument("Piano", "sf2/GeneralUser-GS.sf2", 0, 0)
-project.get_instrument_registry().register_instrument("Jazz Guitar", "sf2/GeneralUser-GS.sf2", 0, 26)
-project.get_instrument_registry().register_instrument("Metronome", "sf2/GeneralUser-GS.sf2", 0, 115)
+    registry = project.get_instrument_registry()
+    registry.register_instrument("Piano", "sf2/GeneralUser-GS.sf2", 0, 0)
+    registry.register_instrument("Jazz Guitar", "sf2/GeneralUser-GS.sf2", 0, 26)
+    registry.register_instrument("Metronome", "sf2/GeneralUser-GS.sf2", 0, 115)
 
-# Create Step Channel
-step_channel_1 = StepChannel("Jazz Guitar")
-step_channel_1.set_step(0, 60, 127)
-step_channel_1.set_step(1, 61, 127)
-step_channel_1.set_step(2, 62, 127)
-step_channel_1.set_step(3, 63, 127)
-step_channel_1.set_step(4, 64, 127)
-step_channel_1.set_step(5, 63, 127)
-step_channel_1.set_step(6, 62, 127)
-step_channel_1.set_step(7, 61, 127)
-step_channel_1.set_step(8, 60, 127)
-step_channel_1.set_step(17, 61, 127)
-step_channel_1.set_step(18, 62, 127)
-step_channel_1.set_step(19, 63, 127)
-step_channel_1.set_step(20, 64, 127)
-step_channel_1.set_step(21, 63, 127)
-step_channel_1.set_step(22, 62, 127)
-step_channel_1.set_step(23, 61, 127)
-step_channel_1.set_step(24, 60, 127)
+    step_channel_1 = StepChannel("Jazz Guitar")
+    step_channel_1.set_step(0, 60, 127)
+    step_channel_1.set_step(1, 61, 127)
+    step_channel_1.set_step(2, 62, 127)
+    step_channel_1.set_step(3, 63, 127)
+    step_channel_1.set_step(4, 64, 127)
+    step_channel_1.set_step(5, 63, 127)
+    step_channel_1.set_step(6, 62, 127)
+    step_channel_1.set_step(7, 61, 127)
+    step_channel_1.set_step(8, 60, 127)
+    step_channel_1.set_step(17, 61, 127)
+    step_channel_1.set_step(18, 62, 127)
+    step_channel_1.set_step(19, 63, 127)
+    step_channel_1.set_step(20, 64, 127)
+    step_channel_1.set_step(21, 63, 127)
+    step_channel_1.set_step(22, 62, 127)
+    step_channel_1.set_step(23, 61, 127)
+    step_channel_1.set_step(24, 60, 127)
 
-# Assign Step Channels
-fs_sound_engine.add_channel(step_channel_1)
+    fs_sound_engine.add_channel(step_channel_1)
 
-# Create Instrument Channels
-for port_name in mido.get_input_names():
-    fluid_midi_channel = FreeMidiChannel(project, port_name, "Piano")
-    project.add_channel(fluid_midi_channel)
+    for port_name in mido.get_input_names():
+        fluid_midi_channel = FreeMidiChannel(project, port_name, "Piano")
+        project.add_channel(fluid_midi_channel)
 
-metronome_channel = FreeMetronomeChannel(project, "Metronome")
-project.add_channel(metronome_channel)
+    metronome_channel = FreeMetronomeChannel(project, "Metronome")
+    project.add_channel(metronome_channel)
 
-step_sequencer_channel = StepSequencerChannel(project, "Step Sequencer")
-project.add_channel(step_sequencer_channel)
+    step_sequencer_channel = StepSequencerChannel(project, "Step Sequencer")
+    project.add_channel(step_sequencer_channel)
 
-# Start curses display
-start_curses_thread(project)
+    return project
 
-# Start the project
-project.play()
 
-# Stop the project after a while (20 seconds)
-time.sleep(20)
-project.stop()
+def parse_arguments(argv: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser(description="Loopy MIDI sequencer")
+    parser.add_argument(
+        "--theme",
+        default="lofi-chill",
+        choices=[theme.key for theme in iter_themes()],
+        help="Select the colour theme for the interface.",
+    )
+    parser.add_argument(
+        "--list-themes",
+        action="store_true",
+        help="List available themes and exit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_arguments(argv)
+
+    if args.list_themes:
+        for theme in iter_themes():
+            print(f"{theme.key}: {theme.display_name} — {theme.description}")
+        return
+
+    try:
+        theme = get_theme(args.theme)
+    except KeyError as error:
+        logging.error(error)
+        return
+
+    project = build_project()
+    start_curses_thread(project, theme)
+
+    project.play()
+    time.sleep(20)
+    project.stop()
+
+
+if __name__ == "__main__":
+    main()
 
 # TODO
 # - Correct Step-Channel MIDI channel

--- a/themes.py
+++ b/themes.py
@@ -1,0 +1,125 @@
+import curses
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+ColorPairDefinition = Tuple[str, Tuple[int, int]]
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Representation of a curses colour theme."""
+
+    key: str
+    display_name: str
+    description: str
+    palette: Sequence[ColorPairDefinition]
+    emphasis: Dict[str, int]
+
+    def apply(self, screen) -> Dict[str, int]:
+        """Initialise the curses colour pairs for the theme and set defaults."""
+        color_ids: Dict[str, int] = {}
+
+        try:
+            curses.start_color()
+            try:
+                curses.use_default_colors()
+            except curses.error:
+                pass
+        except curses.error:
+            return color_ids
+
+        try:
+            if not curses.has_colors():
+                return color_ids
+        except curses.error:
+            return color_ids
+
+        for index, (token, (fg, bg)) in enumerate(self.palette, start=1):
+            try:
+                curses.init_pair(index, fg, bg)
+                color_ids[token] = index
+            except curses.error:
+                # Skip colours the terminal cannot represent.
+                continue
+
+        background_token = "background"
+        if background_token in color_ids:
+            try:
+                screen.bkgd(" ", curses.color_pair(color_ids[background_token]))
+            except curses.error:
+                pass
+
+        return color_ids
+
+    def style(self, token: str, color_ids: Dict[str, int]) -> int:
+        """Return the curses attribute for a styling token."""
+        attribute = curses.A_NORMAL
+        pair_id = color_ids.get(token)
+        if pair_id is not None:
+            attribute |= curses.color_pair(pair_id)
+        emphasis_value = self.emphasis.get(token)
+        if emphasis_value is not None:
+            attribute |= emphasis_value
+        return attribute
+
+
+THEMES: Dict[str, Theme] = {
+    "classic": Theme(
+        key="classic",
+        display_name="Classic Console",
+        description="Monochrome inspired classic theme for broad compatibility.",
+        palette=[
+            ("background", (curses.COLOR_BLACK, -1)),
+            ("title", (curses.COLOR_WHITE, -1)),
+            ("channel_label", (curses.COLOR_WHITE, -1)),
+            ("step_on", (curses.COLOR_GREEN, -1)),
+            ("step_off", (curses.COLOR_WHITE, -1)),
+            ("grid", (curses.COLOR_WHITE, -1)),
+            ("meta", (curses.COLOR_WHITE, -1)),
+        ],
+        emphasis={
+            "title": curses.A_BOLD,
+            "channel_label": curses.A_BOLD,
+            "step_on": curses.A_BOLD,
+        },
+    ),
+    "lofi-chill": Theme(
+        key="lofi-chill",
+        display_name="LoFi Chilly",
+        description="Harmonic teal, magenta and midnight hues for a gem-like chill vibe.",
+        palette=[
+            ("background", (curses.COLOR_BLACK, -1)),
+            ("title", (curses.COLOR_CYAN, -1)),
+            ("channel_label", (curses.COLOR_MAGENTA, -1)),
+            ("step_on", (curses.COLOR_BLACK, curses.COLOR_CYAN)),
+            ("step_off", (curses.COLOR_CYAN, -1)),
+            ("grid", (curses.COLOR_BLUE, -1)),
+            ("meta", (curses.COLOR_WHITE, -1)),
+        ],
+        emphasis={
+            "title": curses.A_BOLD,
+            "channel_label": curses.A_BOLD,
+            "step_on": curses.A_BOLD,
+            "meta": curses.A_DIM,
+        },
+    ),
+}
+
+
+def get_theme(name: str) -> Theme:
+    """Return a theme by its key, raising a KeyError if it doesn't exist."""
+    key = name.lower()
+    if key not in THEMES:
+        raise KeyError(f"Unknown theme '{name}'. Available themes: {', '.join(sorted(THEMES))}")
+    return THEMES[key]
+
+
+def list_theme_keys() -> List[str]:
+    """Return the available theme keys."""
+    return sorted(THEMES.keys())
+
+
+def iter_themes() -> Iterable[Theme]:
+    """Iterate over the available themes."""
+    return THEMES.values()


### PR DESCRIPTION
## Summary
- add a theme system with a LoFi "Chilly" palette and legacy classic option
- render curses UI using the selected theme and expose CLI controls for theme selection
- document the new theme and listing commands in the README

## Testing
- python -m compileall themes.py loopy.py

------
https://chatgpt.com/codex/tasks/task_e_68e180f7f7c083329d34463ab2e14c97