### PR TITLE
Add Tokyo Night theme and set as default

### DIFF
--- a/loopy.py
+++ b/loopy.py
@@ -135,7 +135,7 @@ def parse_arguments(argv: Optional[Sequence[str]] = None):
     parser = argparse.ArgumentParser(description="Loopy MIDI sequencer")
     parser.add_argument(
         "--theme",
-        default="lofi-chill",
+        default="tokyo-night",
         choices=[theme.key for theme in iter_themes()],
         help="Select the colour theme for the interface.",
     )

--- a/themes.py
+++ b/themes.py
@@ -84,6 +84,26 @@ THEMES: Dict[str, Theme] = {
             "step_on": curses.A_BOLD,
         },
     ),
+    "tokyo-night": Theme(
+        key="tokyo-night",
+        display_name="Tokyo Nightfall",
+        description="Blue-forward nocturnal tones inspired by Tokyo's neon skyline.",
+        palette=[
+            ("background", (curses.COLOR_BLACK, -1)),
+            ("title", (curses.COLOR_BLUE, -1)),
+            ("channel_label", (curses.COLOR_CYAN, -1)),
+            ("step_on", (curses.COLOR_BLACK, curses.COLOR_BLUE)),
+            ("step_off", (curses.COLOR_CYAN, -1)),
+            ("grid", (curses.COLOR_MAGENTA, -1)),
+            ("meta", (curses.COLOR_WHITE, -1)),
+        ],
+        emphasis={
+            "title": curses.A_BOLD,
+            "channel_label": curses.A_BOLD,
+            "step_on": curses.A_BOLD,
+            "meta": curses.A_DIM,
+        },
+    ),
     "lofi-chill": Theme(
         key="lofi-chill",
         display_name="LoFi Chilly",


### PR DESCRIPTION
## Summary
- add a Tokyo Night inspired palette with blue-forward highlights to the available themes
- select the new Tokyo Night theme as the default interface palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e182677c048332acf7ae8cd3562c73