### PR TITLE
Raise KeyError when instrument lookup fails

### DIFF
--- a/InstrumentChannel.py
+++ b/InstrumentChannel.py
@@ -12,8 +12,13 @@ class InstrumentChannel:
 
     def set_instrument(self, instrument_name):
         """Sets the channel's instrument based on the instrument name."""
+        synth, channel = self._instrument_registry.get_instrument(instrument_name)
+        if synth is None or channel is None:
+            raise KeyError(f"Instrument '{instrument_name}' is not registered.")
+
         self._instrument_name = instrument_name
-        self._synth, self._channel = self._instrument_registry.get_instrument(instrument_name)
+        self._synth = synth
+        self._channel = channel
 
     def set_volume(self, volume):
         """Sets the channel's volume."""


### PR DESCRIPTION
## Summary
- raise a KeyError when setting an instrument that has not been registered so callers receive a lookup-style error

## Testing
- python -m unittest
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68e1b9d852e883328b0df83d370fc385