### PR TITLE
Handle StepSequencerChannel without registered instrument

### DIFF
--- a/StepSequencerChannel.py
+++ b/StepSequencerChannel.py
@@ -1,11 +1,27 @@
+import logging
+
 from InstrumentChannel import InstrumentChannel
+
 
 class StepSequencerChannel(InstrumentChannel):
     """A channel for a step sequencer."""
 
     def __init__(self, project, name, volume=80):
-        super().__init__(project, name, volume)
-        
+        try:
+            super().__init__(project, name, volume)
+        except KeyError:
+            logging.debug(
+                "Instrument '%s' is not registered — continuing without a synth binding.",
+                name,
+            )
+            self._parent = project
+            self._instrument_registry = project.get_instrument_registry()
+            self._instrument_name = name
+            self._volume = volume
+            self._is_playing = False
+            self._synth = None
+            self._channel = None
+
     def get_sequencer(self):
         """Returns sequencer"""
         return self._parent.get_sequencer()


### PR DESCRIPTION
## Summary
- allow the step sequencer channel to initialize without a registered instrument by falling back to a synth-less configuration
- add debug logging so the missing instrument mapping is visible during diagnostics

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e2206d3020833289ed3a404428c40f