### PR TITLE
Add interactive instrument selection from soundfont in curses UI

### DIFF
--- a/FluidSynthSoundEngine.py
+++ b/FluidSynthSoundEngine.py
@@ -62,6 +62,31 @@ class FluidSynthSoundEngine(SoundEngine):
         """
         self._synth.program_select(channel, sfid, bank, preset)
 
+    def list_presets(self, sfid):
+        """Enumerate available presets for a loaded soundfont."""
+
+        presets = []
+
+        if not hasattr(self._synth, "sfpreset_name"):
+            return presets
+
+        # General MIDI defines 128 banks/programs; iterate defensively.
+        for bank in range(128):
+            for program in range(128):
+                try:
+                    name = self._synth.sfpreset_name(sfid, bank, program)
+                except Exception:  # pragma: no cover - backend specific behaviour
+                    name = None
+                if not name:
+                    continue
+                presets.append({
+                    "bank": bank,
+                    "preset": program,
+                    "name": name,
+                })
+
+        return presets
+
     def channel_info(self, channel):
         """Retrieve information about a specific channel in FluidSynth.
 

--- a/InstrumentChannel.py
+++ b/InstrumentChannel.py
@@ -20,6 +20,14 @@ class InstrumentChannel:
         self._synth = synth
         self._channel = channel
 
+    def get_instrument_name(self):
+        """Return the identifier of the currently selected instrument."""
+        return self._instrument_name
+
+    def get_instrument_label(self):
+        """Return a user friendly name for the currently selected instrument."""
+        return self._instrument_registry.get_instrument_display_name(self._instrument_name)
+
     def set_volume(self, volume):
         """Sets the channel's volume."""
         self._volume = volume

--- a/InstrumentRegistry.py
+++ b/InstrumentRegistry.py
@@ -2,6 +2,9 @@ import logging
 import sys
 import threading
 from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from SoundEngine import SoundEngine
 
@@ -15,6 +18,28 @@ elif sys.platform == "win32":
 else:
     DRIVER = "file"  # Fallback driver
 
+
+@dataclass(frozen=True)
+class PresetMetadata:
+    """Static metadata about a preset inside a soundfont."""
+
+    soundfont_path: str
+    bank: int
+    preset: int
+    name: str
+
+
+@dataclass(frozen=True)
+class InstrumentOption:
+    """Instrument option exposed to the UI for selection."""
+
+    alias: str
+    display_name: str
+    soundfont_path: str
+    bank: int
+    preset: int
+    preset_name: str
+
 class InstrumentRegistry:
     """Manages instrument IDs and maps them to the SoundEngine."""
 
@@ -24,11 +49,16 @@ class InstrumentRegistry:
         Args:
             sound_engine (SoundEngine): The sound engine to use for managing instruments.
         """
-        self._registry = {}  # Stores information about instruments and their channels
-        self._soundfont_cache = {}  # Caches loaded soundfonts (path -> sfid)
+        self._registry: Dict[str, Dict[str, Any]] = {}
+        self._soundfont_cache: Dict[str, int] = {}
         self._sound_engine = sound_engine
         self._available_channels = deque(range(max_channels))
         self._lock = threading.Lock()
+
+        self._soundfont_presets: Dict[str, List[PresetMetadata]] = {}
+        self._preset_aliases: Dict[Tuple[str, int, int], str] = {}
+        self._preset_to_primary_name: Dict[Tuple[str, int, int], str] = {}
+        self._instrument_display_names: Dict[str, str] = {}
 
     def register_instrument(self, instrument_name, soundfont_path, bank=0, preset=0):
         """Registers an instrument with a soundfont and assigns it to a channel.
@@ -48,9 +78,30 @@ class InstrumentRegistry:
             self._soundfont_cache[soundfont_path] = sfid
 
         with self._lock:
+            self._ensure_soundfont_cached(soundfont_path, sfid)
+
             if instrument_name in self._registry:
                 logging.debug("Instrument '%s' already registered.", instrument_name)
                 return self._registry[instrument_name]["channel"]
+
+            metadata = self._find_preset_metadata(soundfont_path, bank, preset)
+            preset_key = (soundfont_path, bank, preset)
+
+            primary_name = self._preset_to_primary_name.get(preset_key)
+            if primary_name:
+                entry = self._registry.get(primary_name)
+                if entry is not None:
+                    self._registry[instrument_name] = entry
+                    display = self._build_display_name(soundfont_path, metadata.name if metadata else instrument_name, bank, preset)
+                    self._instrument_display_names[instrument_name] = display
+                    self._preset_aliases.setdefault(preset_key, self._build_default_alias(soundfont_path, bank, preset))
+                    logging.debug(
+                        "Reusing MIDI channel %d for instrument '%s' (alias of '%s').",
+                        entry["channel"],
+                        instrument_name,
+                        primary_name,
+                    )
+                    return entry["channel"]
 
             if not self._available_channels:
                 raise RuntimeError("No MIDI channels available for new instruments.")
@@ -62,8 +113,19 @@ class InstrumentRegistry:
                 "channel": available_channel,
                 "sfid": sfid,
                 "bank": bank,
-                "preset": preset
+                "preset": preset,
+                "soundfont_path": soundfont_path,
             }
+            self._preset_to_primary_name.setdefault(preset_key, instrument_name)
+            self._preset_aliases.setdefault(preset_key, self._build_default_alias(soundfont_path, bank, preset))
+
+            display_name = self._build_display_name(
+                soundfont_path,
+                metadata.name if metadata else instrument_name,
+                bank,
+                preset,
+            )
+            self._instrument_display_names[instrument_name] = display_name
 
             channel_info = self._sound_engine.channel_info(available_channel)
 
@@ -73,6 +135,58 @@ class InstrumentRegistry:
             )
 
             return available_channel
+
+    def _ensure_soundfont_cached(self, soundfont_path: str, sfid: int) -> None:
+        """Populate preset metadata for a soundfont if necessary."""
+
+        if soundfont_path in self._soundfont_presets:
+            return
+
+        presets: List[PresetMetadata] = []
+        try:
+            raw_presets = self._sound_engine.list_presets(sfid)
+        except AttributeError:
+            raw_presets = []
+        except Exception:  # pragma: no cover - defensive logging for backends without support
+            logging.exception("Failed to enumerate presets for soundfont '%s'.", soundfont_path)
+            raw_presets = []
+
+        if not raw_presets:
+            logging.debug("Soundfont '%s' did not expose preset metadata.", soundfont_path)
+
+        for preset in raw_presets:
+            name = preset.get("name")
+            bank = preset.get("bank")
+            program = preset.get("preset")
+            if name is None or bank is None or program is None:
+                continue
+            metadata = PresetMetadata(soundfont_path, bank, program, name)
+            presets.append(metadata)
+            key = (soundfont_path, bank, program)
+            self._preset_aliases.setdefault(key, self._build_default_alias(soundfont_path, bank, program))
+
+        self._soundfont_presets[soundfont_path] = presets
+
+    def _find_preset_metadata(self, soundfont_path: str, bank: int, preset: int) -> Optional[PresetMetadata]:
+        """Find the cached metadata for a preset if available."""
+
+        for metadata in self._soundfont_presets.get(soundfont_path, []):
+            if metadata.bank == bank and metadata.preset == preset:
+                return metadata
+        return None
+
+    def _build_default_alias(self, soundfont_path: str, bank: int, preset: int) -> str:
+        """Return a deterministic alias for a preset."""
+
+        stem = Path(soundfont_path).stem or soundfont_path
+        return f"{stem}:{bank}:{preset}"
+
+    def _build_display_name(self, soundfont_path: str, preset_name: str, bank: int, preset: int) -> str:
+        """Generate a human friendly label for a preset."""
+
+        stem = Path(soundfont_path).stem or soundfont_path
+        title = preset_name or f"Program {preset}"
+        return f"{title} ({bank}:{preset}) — {stem}"
 
     def get_instrument(self, instrument_name):
         """Returns the SoundEngine instance and the instrument's channel.
@@ -87,6 +201,39 @@ class InstrumentRegistry:
         if instrument:
             return self._sound_engine, instrument["channel"]
         return None, None
+
+    def get_instrument_descriptor(self, instrument_name: str) -> Optional[Dict[str, object]]:
+        """Return metadata about a registered instrument."""
+
+        with self._lock:
+            entry = self._registry.get(instrument_name)
+            if entry is None:
+                return None
+
+            metadata = self._find_preset_metadata(
+                entry.get("soundfont_path", ""),
+                entry.get("bank", 0),
+                entry.get("preset", 0),
+            )
+            alias_key = (
+                entry.get("soundfont_path", ""),
+                entry.get("bank", 0),
+                entry.get("preset", 0),
+            )
+            return {
+                "soundfont_path": entry.get("soundfont_path"),
+                "bank": entry.get("bank"),
+                "preset": entry.get("preset"),
+                "preset_name": metadata.name if metadata else None,
+                "display_name": self._instrument_display_names.get(instrument_name, instrument_name),
+                "alias": self._preset_aliases.get(alias_key),
+            }
+
+    def get_instrument_display_name(self, instrument_name: str) -> str:
+        """Return a human friendly name for an instrument, falling back to its key."""
+
+        with self._lock:
+            return self._instrument_display_names.get(instrument_name, instrument_name)
 
     def unregister_instrument(self, instrument_name):
         """Remove an instrument and release its MIDI channel."""
@@ -106,3 +253,30 @@ class InstrumentRegistry:
             list: A list of registered instrument names.
         """
         return list(self._registry.keys())
+
+    def list_available_instruments(self) -> List[InstrumentOption]:
+        """Return all known presets as instrument options."""
+
+        with self._lock:
+            options: List[InstrumentOption] = []
+            for soundfont_path, presets in self._soundfont_presets.items():
+                for metadata in presets:
+                    alias_key = (soundfont_path, metadata.bank, metadata.preset)
+                    alias = self._preset_aliases.get(alias_key)
+                    if alias is None:
+                        alias = self._build_default_alias(soundfont_path, metadata.bank, metadata.preset)
+                        self._preset_aliases[alias_key] = alias
+                    display = self._build_display_name(soundfont_path, metadata.name, metadata.bank, metadata.preset)
+                    options.append(
+                        InstrumentOption(
+                            alias=alias,
+                            display_name=display,
+                            soundfont_path=soundfont_path,
+                            bank=metadata.bank,
+                            preset=metadata.preset,
+                            preset_name=metadata.name,
+                        )
+                    )
+
+        options.sort(key=lambda option: (Path(option.soundfont_path).name.lower(), option.bank, option.preset))
+        return options

--- a/SoundEngine.py
+++ b/SoundEngine.py
@@ -39,6 +39,11 @@ class SoundEngine(ABC):
         pass
 
     @abstractmethod
+    def list_presets(self, sfid):
+        """Enumerate preset metadata for a loaded soundfont."""
+        pass
+
+    @abstractmethod
     def channel_info(self, channel):
         """Retrieve information about a specific channel.
 

--- a/loopy.py
+++ b/loopy.py
@@ -3,7 +3,7 @@ import curses
 import logging
 import threading
 import time
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import mido
 
@@ -21,54 +21,294 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 def render_curses(screen, project, theme):
     """Curses render function for threading."""
+
+    registry = project.get_instrument_registry()
+    selected_index = 0
+    instrument_menu_open = False
+    instrument_menu_index = 0
+    instrument_menu_page_size = 0
+    instrument_menu_context = {}
+    instrument_options: List = []
+    status_message = ""
+    status_expires = 0.0
+
+    def update_status(message: str, duration: float = 3.0) -> None:
+        nonlocal status_message, status_expires
+        status_message = message
+        status_expires = time.time() + duration
+
+    try:
+        curses.curs_set(0)
+    except curses.error:
+        pass
+
+    try:
+        screen.nodelay(True)
+        screen.keypad(True)
+        screen.timeout(150)
+    except curses.error:
+        pass
+
     try:
         colour_pairs = theme.apply(screen)
+    except Exception:
+        colour_pairs = {}
+
+    try:
         while True:
+            max_y, max_x = screen.getmaxyx()
+            now = time.time()
+            if status_message and now > status_expires:
+                status_message = ""
+
             screen.erase()
-            max_y, _ = screen.getmaxyx()
-            line = 0
 
             header = f"Loopy — {theme.display_name}"
-            screen.addstr(line, 0, header, theme.style("title", colour_pairs))
-            line += 2
+            try:
+                screen.addnstr(0, 0, header, max_x - 1, theme.style("title", colour_pairs))
+            except curses.error:
+                pass
+            line = 2
 
-            for i, channel in enumerate(project.get_channels()):
-                if line >= max_y - 1:
+            selectables = []
+            channels = project.get_channels()
+            for index, channel in enumerate(channels):
+                if line >= max_y - 2:
                     break
 
-                channel_label = f"Channel {i + 1}: {channel._instrument_name}"
-                screen.addstr(line, 0, channel_label, theme.style("channel_label", colour_pairs))
+                if hasattr(channel, "get_instrument_label"):
+                    instrument_label = channel.get_instrument_label()
+                elif hasattr(channel, "get_instrument_name"):
+                    instrument_label = registry.get_instrument_display_name(channel.get_instrument_name())
+                else:
+                    instrument_label = str(channel)
+
+                channel_index = len(selectables)
+                selectables.append({"type": "channel", "target": channel})
+                attr = theme.style("channel_label", colour_pairs)
+                if channel_index == selected_index:
+                    attr |= curses.A_REVERSE
+
+                channel_label = f"Channel {index + 1}: {instrument_label}"
+                try:
+                    screen.addnstr(line, 0, channel_label, max_x - 1, attr)
+                except curses.error:
+                    pass
+                line += 1
 
                 if isinstance(channel, StepSequencerChannel):
                     sequencer = channel.get_sequencer()
                     step_channels = sequencer.get_channels()
 
                     for step_channel in step_channels:
-                        line += 1
-                        if line >= max_y - 1:
+                        if line >= max_y - 2:
                             break
 
-                        screen.addstr(line, 3, "[", theme.style("grid", colour_pairs))
-                        for j, step in enumerate(step_channel.get_steps()):
-                            column = j * 2 + 4
-                            token = "step_off"
-                            glyph = "o-"
-                            if step is not None:
-                                note, velocity = step
-                                if note is not None and velocity is not None:
-                                    token = "step_on"
-                                    glyph = "x-"
-                            screen.addstr(line, column, glyph, theme.style(token, colour_pairs))
-                        screen.addstr(line, 67, "]", theme.style("grid", colour_pairs))
+                        step_index = len(selectables)
+                        selectables.append({"type": "step_channel", "target": step_channel})
+                        highlight = step_index == selected_index
 
-                line += 1
+                        step_label = registry.get_instrument_display_name(step_channel.get_instrument_name())
+                        label_attr = theme.style("channel_label", colour_pairs)
+                        if highlight:
+                            label_attr |= curses.A_REVERSE
+                        try:
+                            screen.addnstr(line, 0, f"    {step_label}", max_x - 1, label_attr)
+                        except curses.error:
+                            pass
 
+                        grid_attr = theme.style("grid", colour_pairs)
+                        if highlight:
+                            grid_attr |= curses.A_REVERSE
+
+                        if max_x > 4:
+                            try:
+                                screen.addstr(line, 3, "[", grid_attr)
+                            except curses.error:
+                                pass
+
+                            steps = step_channel.get_steps() or []
+                            visible_steps = max(0, min(len(steps), (max_x - 6) // 2))
+                            for j, step in enumerate(steps[:visible_steps]):
+                                column = j * 2 + 4
+                                token = "step_off"
+                                glyph = "o-"
+                                if step is not None:
+                                    note, velocity = step
+                                    if note is not None and velocity is not None:
+                                        token = "step_on"
+                                        glyph = "x-"
+                                style = theme.style(token, colour_pairs)
+                                if highlight:
+                                    style |= curses.A_REVERSE
+                                try:
+                                    screen.addnstr(line, column, glyph, max_x - column - 1, style)
+                                except curses.error:
+                                    pass
+
+                            closing_column = min(max_x - 2, 4 + visible_steps * 2)
+                            try:
+                                screen.addstr(line, closing_column, "]", grid_attr)
+                            except curses.error:
+                                pass
+
+                        line += 1
+
+            if selectables:
+                selected_index = max(0, min(selected_index, len(selectables) - 1))
+            else:
+                selected_index = 0
+
+            footer_attr = theme.style("meta", colour_pairs)
             footer_line = max_y - 1
-            footer = f"Theme: {theme.display_name} ({theme.key})"
-            screen.addstr(footer_line, 0, footer, theme.style("meta", colour_pairs))
+            status_line = footer_line - 1
+
+            if status_message and status_line >= 0:
+                try:
+                    screen.addnstr(status_line, 0, status_message, max_x - 1, footer_attr)
+                except curses.error:
+                    pass
+
+            if instrument_menu_open:
+                instruction = "↑/↓ Navigate · Enter Apply · Esc Cancel"
+            else:
+                instruction = "↑/↓ Select · i Change instrument"
+            footer = f"Theme: {theme.display_name} ({theme.key}) | {instruction}"
+            try:
+                screen.addnstr(footer_line, 0, footer, max_x - 1, footer_attr)
+            except curses.error:
+                pass
+
+            overlay_window = None
+            instrument_menu_page_size = 0
+            if instrument_menu_open and instrument_options:
+                menu_height = min(max_y - 4, len(instrument_options) + 2)
+                menu_height = max(menu_height, 3)
+                menu_width = min(max_x - 4, max(len(option.display_name) for option in instrument_options) + 4)
+                menu_width = max(menu_width, 32)
+                start_y = max(1, (max_y - menu_height) // 2)
+                start_x = max(1, (max_x - menu_width) // 2)
+
+                try:
+                    overlay_window = screen.subwin(menu_height, menu_width, start_y, start_x)
+                    overlay_window.box()
+                except curses.error:
+                    overlay_window = None
+
+                if overlay_window is not None:
+                    instrument_menu_page_size = menu_height - 2
+                    current_descriptor = instrument_menu_context.get("current_descriptor")
+                    visible_rows = instrument_menu_page_size
+                    scroll_offset = min(
+                        max(0, instrument_menu_index - visible_rows + 1),
+                        max(0, len(instrument_options) - visible_rows),
+                    )
+
+                    for row in range(visible_rows):
+                        option_index = scroll_offset + row
+                        if option_index >= len(instrument_options):
+                            break
+                        option = instrument_options[option_index]
+                        prefix = "  "
+                        if current_descriptor and option.soundfont_path == current_descriptor.get("soundfont_path") \
+                                and option.bank == current_descriptor.get("bank") \
+                                and option.preset == current_descriptor.get("preset"):
+                            prefix = "→ "
+                        text = f"{prefix}{option.display_name}"
+                        attr = theme.style("channel_label", colour_pairs)
+                        if option_index == instrument_menu_index:
+                            attr |= curses.A_REVERSE
+                        try:
+                            overlay_window.addnstr(1 + row, 1, text, menu_width - 2, attr)
+                        except curses.error:
+                            pass
 
             screen.refresh()
-            time.sleep(0.5)
+            if overlay_window is not None:
+                overlay_window.refresh()
+
+            try:
+                key = screen.getch()
+            except curses.error:
+                key = -1
+
+            if key == curses.ERR or key == -1:
+                continue
+
+            if instrument_menu_open:
+                if key in (curses.KEY_UP, ord("k")):
+                    instrument_menu_index = max(0, instrument_menu_index - 1)
+                elif key in (curses.KEY_DOWN, ord("j")):
+                    instrument_menu_index = min(len(instrument_options) - 1, instrument_menu_index + 1)
+                elif key == curses.KEY_PPAGE:
+                    step = max(1, instrument_menu_page_size)
+                    instrument_menu_index = max(0, instrument_menu_index - step)
+                elif key == curses.KEY_NPAGE:
+                    step = max(1, instrument_menu_page_size)
+                    instrument_menu_index = min(len(instrument_options) - 1, instrument_menu_index + step)
+                elif key in (curses.KEY_ENTER, 10, 13):
+                    if 0 <= instrument_menu_index < len(instrument_options):
+                        option = instrument_options[instrument_menu_index]
+                        try:
+                            registry.register_instrument(
+                                option.alias,
+                                option.soundfont_path,
+                                option.bank,
+                                option.preset,
+                            )
+                            target = instrument_menu_context.get("target")
+                            if target:
+                                target_obj = target.get("target")
+                                if hasattr(target_obj, "set_instrument"):
+                                    target_obj.set_instrument(option.alias)
+                            update_status(f"Instrument set to {option.display_name}", 4.0)
+                        except Exception as error:  # pragma: no cover - defensive logging
+                            update_status(f"Failed to select instrument: {error}", 6.0)
+                        instrument_menu_open = False
+                elif key in (27, ord("q")):
+                    instrument_menu_open = False
+                    update_status("Cancelled instrument selection", 2.0)
+            else:
+                if key in (curses.KEY_UP, ord("k")):
+                    if selectables:
+                        selected_index = max(0, selected_index - 1)
+                elif key in (curses.KEY_DOWN, ord("j")):
+                    if selectables:
+                        selected_index = min(len(selectables) - 1, selected_index + 1)
+                elif key == ord("i"):
+                    if not selectables:
+                        update_status("No channels available", 2.0)
+                        continue
+
+                    instrument_options = registry.list_available_instruments()
+                    if not instrument_options:
+                        update_status("No instruments available", 3.0)
+                        continue
+
+                    target = selectables[selected_index]
+                    instrument_menu_context = {"target": target}
+
+                    descriptor = None
+                    target_obj = target.get("target")
+                    if hasattr(target_obj, "get_instrument_name"):
+                        descriptor = registry.get_instrument_descriptor(target_obj.get_instrument_name())
+                    instrument_menu_context["current_descriptor"] = descriptor
+
+                    instrument_menu_index = 0
+                    if descriptor:
+                        for idx, option in enumerate(instrument_options):
+                            if (
+                                option.soundfont_path == descriptor.get("soundfont_path")
+                                and option.bank == descriptor.get("bank")
+                                and option.preset == descriptor.get("preset")
+                            ):
+                                instrument_menu_index = idx
+                                break
+
+                    instrument_menu_open = True
+                elif key in (ord("q"), ord("Q")):
+                    update_status("Press Ctrl+C to exit.", 2.0)
+
     except curses.error:
         pass
     except Exception as error:  # pragma: no cover - defensive logging for curses thread


### PR DESCRIPTION
## Summary
- enumerate soundfont presets via FluidSynth and expose the data through the instrument registry
- surface friendly instrument labels on instrument channels for display and selection
- overhaul the curses UI so instruments can be chosen per channel while the project runs

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e2225a10148332ab45dbb3f17783b5