### PR TITLE
Add console script entry for uv run loopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ flowchart LR
 
 ## Running with uv
 
-This project is distributed as a module rather than a console script, so
-`uv run loopy` will not find an entry point. Use Python's module launcher
-instead:
+Loopy now exposes a console script entry point, so you can launch it directly
+with `uv run`:
 
 ```bash
-uv run -- python -m loopy.loopy
+uv run loopy
 ```
 
-You can pass all of the usual CLI flags, for example:
+All of the CLI flags continue to work and can be passed without the additional
+`python -m` invocation:
 
 ```bash
-uv run -- python -m loopy.loopy --theme lofi-chill
-uv run -- python -m loopy.loopy --list-themes
+uv run loopy --theme lofi-chill
+uv run loopy --list-themes
 ```
 
 > [!NOTE]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 
+[project.scripts]
+loopy = "loopy.loopy:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/loopy"]
 


### PR DESCRIPTION
## Summary
- expose the loopy console script entry point so `uv run loopy` launches the app
- update the README instructions to reference the direct `uv run loopy` usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e28a2f43a48332a622153510df3d9e